### PR TITLE
fix: Change profile props to return 404 if path is not valid instead of 500

### DIFF
--- a/src/pages/profiles/[userID].tsx
+++ b/src/pages/profiles/[userID].tsx
@@ -84,7 +84,7 @@ export const getStaticPaths = async () => {
     },
   }));
 
-  return { paths: params, fallback: "blocking" };
+  return { paths: params, fallback: false };
 };
 
 export default UserProfile;


### PR DESCRIPTION
Entering a profile path such as "/profiles/nonsense" would previously return a 500 internal server error rather than the appropriate 404 not found error. 

This has the unfortunate side effect of making all errors into 404s for the `getProfileInformation` promise. I experimented with ways to be more specific but I could not find a solution.