### PR TITLE
feat: Profile Listing

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -5,14 +5,14 @@ import {Button, Container, Stack} from "@mui/material"
 import {TextField} from "formik-mui"
 import * as Yup from 'yup';
 import { GetUserResponse } from "@/pages/api/userSession";
-import { ProfileInformation } from "@/lib/database";
+import { Profile } from "@/lib/database";
 import Router from "next/router";
 import { StatusAlert, SubmitButton } from "./FormComponents";
 
 
 const MESSAGE_CHARACTER_LIMIT = 3000;
 
-const Contact = (props: {user: GetUserResponse, userToContact: ProfileInformation}) => {
+const Contact = (props: {user: GetUserResponse, userToContact: Profile}) => {
   const ContactUserSchema = Yup.object().shape({
     message: Yup.string()
         .min(2, 'Too Short!')

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,6 +36,9 @@ const logged_in_header_elements = (
     <Link href="/lessons" className={styles.headerElement} key="login">
       Lesson Plans
     </Link>,
+    <Link href="/profile-search" className={styles.headerElement} key="profile-search">
+      User Profiles    
+    </Link>,
     <Link
       href={`/profiles/${user.userID}`}
       className={styles.headerElement}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -151,12 +151,10 @@ export const getProfiles = async (
   sortKey?: string, // Fields to sort by, TODO: make this an enum
   sortDirection?: number // 1 for ascending, -1 for descending
 ) => {
-  // Get Lesson Plans for listing page
   const client = await establishMongoConnection();
   const collection = getUserCollection(client)
   const profiles = await collection.find({}).toArray();
   client.close();
-  // TODO: exclude email, password and _id
   const typedProfiles: Profile[] = profiles.map(
     (profile) => (getLimitedProfile(profile))
   );

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -84,11 +84,11 @@ export const getMongoUser = async (userID: string) => {
   return userInfoSerializable;
 };
 
-export type ProfileInformation = Omit<User, "password" | "joinDate"> 
+export type Profile = Omit<User, "password" | "joinDate"> 
 
-export const getProfileInformation = async (
+export const getProfile = async (
   userID: string
-): Promise<ProfileInformation> => {
+): Promise<Profile> => {
   const rawUser = await getMongoUser(userID);
   return {
     userID: rawUser._id,
@@ -136,6 +136,29 @@ export const getLessonPlans = async (
       subject: lesson.subject,
     })
   );
-
   return TypedLessonPlans;
 };
+
+const getLimitedProfile = (profile: WithId<Omit<User, "userID">>) => {
+  const {_id, password, joinDate, ...limitedProfile} = profile;
+  return {
+    userID: profile._id.toString(),
+    ...limitedProfile
+  }
+}
+
+export const getProfiles = async (
+  sortKey?: string, // Fields to sort by, TODO: make this an enum
+  sortDirection?: number // 1 for ascending, -1 for descending
+) => {
+  // Get Lesson Plans for listing page
+  const client = await establishMongoConnection();
+  const collection = getUserCollection(client)
+  const profiles = await collection.find({}).toArray();
+  client.close();
+  // TODO: exclude email, password and _id
+  const typedProfiles: Profile[] = profiles.map(
+    (profile) => (getLimitedProfile(profile))
+  );
+  return typedProfiles;
+}

--- a/src/pages/api/editUser.ts
+++ b/src/pages/api/editUser.ts
@@ -44,4 +44,5 @@ export default async function postEditUser(
                 }
             )
     )
+    res.revalidate("/profile-search")
 }

--- a/src/pages/api/user.ts
+++ b/src/pages/api/user.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { User } from "@/pages/api/userSession";
-import { establishMongoConnection, getMongoUser, getProfileInformation, getUserCollection } from "@/lib/database";
+import { establishMongoConnection, getMongoUser, getProfile, getUserCollection } from "@/lib/database";
 
 export interface PostUserResponse {
   message: string;
@@ -25,7 +25,7 @@ export default async function postUser(
     if(idToFetch === undefined || Array.isArray(idToFetch)){
       return res.status(400)
     }
-    const user = await getProfileInformation(idToFetch)
+    const user = await getProfile(idToFetch)
 
     return res.status(200).json(user);
   }

--- a/src/pages/api/user.ts
+++ b/src/pages/api/user.ts
@@ -54,6 +54,7 @@ export default async function postUser(
     res.status(200).json({
       message: "Successfully added user.",
     });
+    res.revalidate("/profile-search")
     return;
   }
 }

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -4,14 +4,14 @@ import useSWR from "swr";
 import Head from "next/head";
 import Contact from "@/components/Contact";
 import { useRouter } from 'next/router'
-import { ProfileInformation } from "@/lib/database";
+import { Profile } from "@/lib/database";
 
  
 const ContactPage = () => {
     const router = useRouter()
     const userToContactID = router.query.user
 
-    const { data: userToContact, error} = useSWR<ProfileInformation>(`/api/user?userID=${userToContactID}`);
+    const { data: userToContact, error} = useSWR<Profile>(`/api/user?userID=${userToContactID}`);
     if(error){
         console.error(error)
     }

--- a/src/pages/lessons.tsx
+++ b/src/pages/lessons.tsx
@@ -41,10 +41,10 @@ const Footer: React.FC = () => {
   return (
     <>
       <div className={styles.lessonFooter}>
-        <text>
+        <p>
           For more information on lesson plans, contact your region&apos;s
           SciREN Organization.
-        </text>
+        </p>
       </div>
     </>
   );
@@ -70,14 +70,14 @@ const LessonCard: React.FC<Lesson> = (lesson: Lesson) => {
           {lesson.year ? " - " + lesson.year : ""}
         </h2>
 
-        <text className={styles.authorText}>
+        <p className={styles.authorText}>
           {lesson.authors.map((author, i) => (
-            <a href={`mailto:${author.contact}`} key={author.contact}>
+            <a href={`mailto:${author.contact}`} key={`${author.contact}-${i}`}>
               {author.name}
               {i < lesson.authors.length - 1 ? ", " : ""}
             </a>
           ))}
-        </text>
+        </p>
 
         <hr className={styles.divider} />
         <div
@@ -135,8 +135,8 @@ const LessonFragment: React.FC<{
     <>
       {
         // Wrapped in a fragment to satisfy type checks
-        props.lessons.map((lesson: Lesson) => (
-          <LessonCard key={lesson._id} {...lesson} />
+        props.lessons.map((lesson: Lesson, index) => (
+          <LessonCard key={`lesson-plan${index}`} {...lesson} />
         ))
       }
     </>

--- a/src/pages/profile-search.tsx
+++ b/src/pages/profile-search.tsx
@@ -9,6 +9,7 @@ import { GetUserResponse } from "./api/userSession";
 import { Stack, capitalize } from "@mui/material";
 import Link from "next/link";
 import { commaSeparateList, getAvatar } from "./profiles/[userID]";
+import { gradeRangeOptions } from "./edit-profile";
 
 interface ProfileListProps {
   profiles: Profile[];
@@ -37,8 +38,6 @@ const ProfileList: React.FC<ProfileListProps> = (props: ProfileListProps) => {
     </>
   );
 };
-
-
 
 export const getStaticProps: GetStaticProps = async (
   context: GetStaticPropsContext
@@ -81,6 +80,13 @@ const ProfileCard: React.FC<Profile> = (profile: Profile) => {
           <p>
             Region: {profile.scirenRegion}
           </p>
+          {profile.userType === "teacher" &&
+          <p>
+            Grades Taught: {commaSeparateList(profile.gradeRange.map(
+              (value) => gradeRangeOptions[value]
+            ))}
+          </p>
+          }
         </div>
 
         <div className={styles.linkContainer}>

--- a/src/pages/profile-search.tsx
+++ b/src/pages/profile-search.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Head from "next/head";
 import { GetStaticProps, GetStaticPropsContext } from "next";
-import { Lesson, Profile, getProfiles } from "@/lib/database";
+import { Profile, getProfiles } from "@/lib/database";
 import styles from "@/styles/List.module.css";
 import Button from "@mui/material/Button";
 import useUser from "@/lib/useUser";
-import { gradeRangeOptions } from "./edit-profile";
 import { GetUserResponse } from "./api/userSession";
-import { capitalize } from "@mui/material";
+import { Stack, capitalize } from "@mui/material";
 import Link from "next/link";
+import { commaSeparateList, getAvatar } from "./profiles/[userID]";
 
 interface ProfileListProps {
   profiles: Profile[];
@@ -29,9 +29,8 @@ const ProfileList: React.FC<ProfileListProps> = (props: ProfileListProps) => {
       </Head>
       {user && user.isLoggedIn ? 
         <main className={styles.mainContainer}>
-          <h1 className={styles.listTitle}>SciREN Profiles</h1>
+          <h1 className={styles.profileListTitle}>SciREN Profiles</h1>
           <ProfileFragment profiles={props.profiles} />
-          <Footer />
         </main>:
         <h1>Loading...</h1>
       }
@@ -39,18 +38,7 @@ const ProfileList: React.FC<ProfileListProps> = (props: ProfileListProps) => {
   );
 };
 
-const Footer: React.FC = () => {
-  return (
-    <>
-      <div className={styles.lessonFooter}>
-        <text>
-          For more information on lesson plans, contact your region&apos;s
-          SciREN Organization.
-        </text>
-      </div>
-    </>
-  );
-};
+
 
 export const getStaticProps: GetStaticProps = async (
   context: GetStaticPropsContext
@@ -64,14 +52,16 @@ const ProfileCard: React.FC<Profile> = (profile: Profile) => {
   const [isCollapsed, setIsCollapsed] = useState(true);
   return (
     <div>
-      <div className={styles.lessonContainer}>
-        <h2 className="lessonTitle">
-          {profile.firstName} {profile.lastName}
-        </h2>
-        <h3>
-            {capitalize(profile.userType)} {profile.organizations.length > 0 && `at ${profile.organizations[0]}`}
-        </h3>
-
+      <div className={styles.profileContainer}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            {getAvatar(profile.firstName, profile.lastName)}
+            <Stack direction="column">
+              <h2 className="lessonTitle"> {profile.firstName} {profile.lastName} </h2>
+              <p className={styles.authorText}>
+              {capitalize(profile.userType)} {profile.organizations.length > 0 && `at ${profile.organizations[0]}`}
+              </p>
+            </Stack>
+          </Stack>
         <hr className={styles.divider} />
         <div
           onMouseEnter={() => setIsCollapsed(false)}
@@ -83,12 +73,15 @@ const ProfileCard: React.FC<Profile> = (profile: Profile) => {
           {profile.textBio}
         </div>
 
-        {/* <div className={styles.gradeBox}>
+        <div className={styles.gradeBox}>
           <p className={styles.categoryText}>
-            Research Areas: {lesson.gradeLevel.map((gi) => gradeRangeOptions[gi]).join(", ")}
+            {profile.userType === "teacher" ? "Subjects Taught: " : "Research Areas: "}
+            {commaSeparateList(profile.academicInterest)}
           </p>
-          <p className={styles.categoryText}>Subject: {lesson.subject}</p>
-        </div> */}
+          <p>
+            Region: {profile.scirenRegion}
+          </p>
+        </div>
 
         <div className={styles.linkContainer}>
           <Link href={`/profiles/${profile.userID}`} passHref>

--- a/src/pages/profile-search.tsx
+++ b/src/pages/profile-search.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from "react";
+import Head from "next/head";
+import { GetStaticProps, GetStaticPropsContext } from "next";
+import { Lesson, Profile, getProfiles } from "@/lib/database";
+import styles from "@/styles/List.module.css";
+import Button from "@mui/material/Button";
+import useUser from "@/lib/useUser";
+import { gradeRangeOptions } from "./edit-profile";
+import { GetUserResponse } from "./api/userSession";
+import { capitalize } from "@mui/material";
+import Link from "next/link";
+
+interface ProfileListProps {
+  profiles: Profile[];
+  undefined: boolean;
+}
+
+const ProfileList: React.FC<ProfileListProps> = (props: ProfileListProps) => {
+  const { user} = useUser(
+    (user: GetUserResponse) => "/login"
+  );
+  return (
+    <>
+      <Head>
+        <title>Profile Search - SciREN</title>
+        <meta name="description" content="SciREN Profile List" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      {user && user.isLoggedIn ? 
+        <main className={styles.mainContainer}>
+          <h1 className={styles.listTitle}>SciREN Profiles</h1>
+          <ProfileFragment profiles={props.profiles} />
+          <Footer />
+        </main>:
+        <h1>Loading...</h1>
+      }
+    </>
+  );
+};
+
+const Footer: React.FC = () => {
+  return (
+    <>
+      <div className={styles.lessonFooter}>
+        <text>
+          For more information on lesson plans, contact your region&apos;s
+          SciREN Organization.
+        </text>
+      </div>
+    </>
+  );
+};
+
+export const getStaticProps: GetStaticProps = async (
+  context: GetStaticPropsContext
+) => {
+  const profiles: Profile[] | undefined = await getProfiles()
+  const notFound = !profiles;
+  return { props: { profiles: profiles, notFound } };
+};
+
+const ProfileCard: React.FC<Profile> = (profile: Profile) => {
+  const [isCollapsed, setIsCollapsed] = useState(true);
+  return (
+    <div>
+      <div className={styles.lessonContainer}>
+        <h2 className="lessonTitle">
+          {profile.firstName} {profile.lastName}
+        </h2>
+        <h3>
+            {capitalize(profile.userType)} {profile.organizations.length > 0 && `at ${profile.organizations[0]}`}
+        </h3>
+
+        <hr className={styles.divider} />
+        <div
+          onMouseEnter={() => setIsCollapsed(false)}
+          onMouseLeave={() => setIsCollapsed(true)}
+          className={`${styles.lessonAbstract} ${
+            isCollapsed ? styles.lessonAbstractCollapsed : ""
+          }`}
+        >
+          {profile.textBio}
+        </div>
+
+        {/* <div className={styles.gradeBox}>
+          <p className={styles.categoryText}>
+            Research Areas: {lesson.gradeLevel.map((gi) => gradeRangeOptions[gi]).join(", ")}
+          </p>
+          <p className={styles.categoryText}>Subject: {lesson.subject}</p>
+        </div> */}
+
+        <div className={styles.linkContainer}>
+          <Link href={`/profiles/${profile.userID}`} passHref>
+            <Button variant="contained">View Profile</Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ProfileFragment: React.FC<{
+  profiles: Profile[];
+}> = (props) => {
+  return (
+    <>
+      {
+        // Wrapped in a fragment to satisfy type checks
+        props.profiles.map((profile: Profile) => (
+          <ProfileCard key={profile.userID} {...profile} />
+        ))
+      }
+    </>
+  );
+};
+
+export default ProfileList;

--- a/src/pages/profiles/[userID].tsx
+++ b/src/pages/profiles/[userID].tsx
@@ -4,16 +4,16 @@ import Link from "next/link";
 import Image from "next/image";
 import useUser from "@/lib/useUser";
 import {
-  ProfileInformation,
+  Profile,
   getAllUserIDs,
-  getProfileInformation,
+  getProfile,
 } from "@/lib/database";
 import { GetStaticPropsContext } from "next";
 import styles from "@/styles/Profile.module.css";
 import { Box, Button, Divider, List, ListItem, capitalize } from "@mui/material";
 
-const UserProfile: React.FC<ProfileInformation> = (
-  props: ProfileInformation
+const UserProfile: React.FC<Profile> = (
+  props: Profile
 ) => {
   const { user } = useUser();
 
@@ -134,7 +134,7 @@ export const getStaticProps = async ({
   userID: string;
 }>) => {
   const { userID } = params as { userID: string };
-  const user = await getProfileInformation(userID).catch((reason) => {console.log(reason); return undefined});
+  const user = await getProfile(userID).catch((reason) => {console.log(reason); return undefined});
   const notFound = !user;
   return { props: user, notFound };
 };

--- a/src/pages/profiles/[userID].tsx
+++ b/src/pages/profiles/[userID].tsx
@@ -90,7 +90,8 @@ const UserProfile: React.FC<Profile> = (
 
 
 
-const commaSeparateList = (list: string[]) => {
+
+export const commaSeparateList = (list: string[]) => {
   return (list.map(
     (val, i) => (
       <>
@@ -115,7 +116,7 @@ const editButton = () => {
   )
 }
 
-const getAvatar = (firstName: string, lastName: string) => {
+export const getAvatar = (firstName: string, lastName: string) => {
   return (
     <Avatar  
       sx={{

--- a/src/pages/profiles/[userID].tsx
+++ b/src/pages/profiles/[userID].tsx
@@ -11,6 +11,7 @@ import {
 import { GetStaticPropsContext } from "next";
 import styles from "@/styles/Profile.module.css";
 import { Avatar, Box, Button, Divider, Stack, capitalize } from "@mui/material";
+import { gradeRangeOptions } from "../edit-profile";
 
 const UserProfile: React.FC<Profile> = (
   props: Profile
@@ -56,6 +57,19 @@ const UserProfile: React.FC<Profile> = (
           <p className={styles.profileParagraph}>
             {commaSeparateList(props.academicInterest)}
           </p>
+
+          {props.userType === "teacher" && 
+          <div>
+            <h3 className={styles.profileHeading}>Grades Taught</h3>
+            <Divider></Divider>
+            <p className={styles.profileParagraph}>
+              {commaSeparateList(props.gradeRange.map(
+                (value) => gradeRangeOptions[value]
+              ))}
+            </p>
+          </div>
+          }
+
           <h3 className={styles.profileHeading}>
             Affiliated Organization{multipleOrgs ? "s": ""}
             <Divider></Divider>

--- a/src/styles/List.module.css
+++ b/src/styles/List.module.css
@@ -5,6 +5,7 @@
   padding: 10px 20vw 10px 10vw;
 }
 
+
 .lessonContainer {
   background: aliceblue;
   color: black;
@@ -12,6 +13,18 @@
   margin: 25px 0;
   border-radius: 5px;
   max-width: 80vw;
+  margin: auto auto;
+  margin-top: 20px;
+  box-shadow: #1c1c1c81 4px 4px 2px;
+}
+
+.profileContainer {
+  background: aliceblue;
+  color: black;
+  padding: 25px;
+  margin: 25px 0;
+  border-radius: 5px;
+  max-width: 60vw;
   margin: auto auto;
   margin-top: 20px;
   box-shadow: #1c1c1c81 4px 4px 2px;
@@ -31,6 +44,12 @@
 
 .listTitle {
   color: aliceblue;
+}
+
+.profileListTitle {
+  color: aliceblue;
+  margin: auto auto;
+  max-width: 60vw;
 }
 
 .lessonFooter {


### PR DESCRIPTION
Mostly just copied lesson plan listing.
Changes in this PR:
* Added `profile-search` page
  * Currently only lists all profiles in `usersv2`
* added link to profile-search in header
* minor changes to lesson plan listing to get rid of console errors